### PR TITLE
Bugfix: disable uglify for markup files

### DIFF
--- a/lib/deliveryPacker.js
+++ b/lib/deliveryPacker.js
@@ -245,9 +245,6 @@ var buildDelivery = function (options, dest) {
         builder = buildify("", {quiet: true})
             .setDir(setDir)
             .concat(filesMarkup);
-        if (options.minimize === true) {
-            builder.uglify();
-        }
         builder.save(path.join(dest, prefix + ".html"));
         log(options, "creating " + colors.cyan.bold(path.join(dest, prefix + ".html")));
     }


### PR DESCRIPTION
uglify-js can't parse HTML files
